### PR TITLE
Fix macrobody

### DIFF
--- a/python/MCNPInput.py
+++ b/python/MCNPInput.py
@@ -592,7 +592,8 @@ class MCNPInput(InputDeck):
             cell_description_outside += ":-" + str(new_surf_list[3].surface_id)
             cell_description_outside += ":-"  + str(new_surf_list[4].surface_id)
             cell_description_outside += ":-" + str(new_surf_list[5].surface_id)          
-
+            cell_description_outside += ")"
+            
             cell_description = [cell_description_inside,cell_description_outside]
         else:
             warnings.warn('Found an unsupported macrobody, files will not be correct',Warning)

--- a/python/MCNPInput.py
+++ b/python/MCNPInput.py
@@ -3,6 +3,7 @@
 from Input import InputDeck #, get_surface_with_id
 from SurfaceCard import SurfaceCard #, BoundaryCondition
 from ParticleNames import particleToGeneric, ParticleNames
+from MaterialCard import get_material_colour
 from MCNPParticleNames import mcnpToParticle
 from MCNPFormatter import strip_dollar_comments
 from MCNPCellCard import MCNPCellCard, is_cell_card, write_mcnp_cell
@@ -188,8 +189,14 @@ class MCNPInput(InputDeck):
             break
 
         material = MCNPMaterialCard(mat_num, material_string)
+        # set the colour based on the number of colours
+        # but only if its really used rather than a tally
+        # multiplier material
+        if material.density > 0:
+            material.material_colour = get_material_colour(len(self.material_list))
         self.material_list[material.material_number] = material
-
+        
+        
         return
 
     # get the material cards definitions

--- a/python/MCNPInput.py
+++ b/python/MCNPInput.py
@@ -398,7 +398,7 @@ class MCNPInput(InputDeck):
         self.last_free_surface_index += 1
         surface_string = str(self.last_free_surface_index) + " p "
         for coeff in axis_vector:
-            surface_string += str(coeff) + " "
+            surface_string += str(-1.*coeff) + " "
         surface_string += str(d1)
         surf = MCNPSurfaceCard(surface_string) # todo maybe instanciate explicitly generically?
         new_surf_list.append(surf)
@@ -419,13 +419,13 @@ class MCNPInput(InputDeck):
 
         cell_description_inside = "("
         cell_description_inside += " -" + str(new_surf_list[0].surface_id)
-        cell_description_inside += "  " + str(new_surf_list[1].surface_id)
+        cell_description_inside += " -" + str(new_surf_list[1].surface_id)
         cell_description_inside += " -"  + str(new_surf_list[2].surface_id)
         cell_description_inside += ")"
 
         cell_description_outside = "("
         cell_description_outside += str(new_surf_list[0].surface_id)
-        cell_description_outside += ":-" + str(new_surf_list[1].surface_id)
+        cell_description_outside += ":" + str(new_surf_list[1].surface_id)
         cell_description_outside += ":" + str(new_surf_list[2].surface_id)
         cell_description_outside += ")"
 
@@ -475,13 +475,13 @@ class MCNPInput(InputDeck):
 
         cell_description_inside = "("
         cell_description_inside += " -" + str(new_surf_list[0].surface_id)
-        cell_description_inside += " " + str(new_surf_list[1].surface_id)
+        cell_description_inside += " -" + str(new_surf_list[1].surface_id)
         cell_description_inside += " -" + str(new_surf_list[2].surface_id)
         cell_description_inside += ")"
 
         cell_description_outside = "("
         cell_description_outside += "  " +str(new_surf_list[0].surface_id)
-        cell_description_outside += ":-" + str(new_surf_list[1].surface_id)
+        cell_description_outside += ":" + str(new_surf_list[1].surface_id)
         cell_description_outside += ":" + str(new_surf_list[2].surface_id)
         cell_description_outside += ")"
 
@@ -492,40 +492,45 @@ class MCNPInput(InputDeck):
     # explode a macrobody into surfaces
     def explode_macrobody(self,Surface):
         new_surf_list = []
+        # NOTE MCNP Macrobodies have +ve sense outside of it, and -ve sense inside
+        # of it. Therefore, on a RPP the first index is the right hand side of the cube
+        # and the 2nd is the left hand side
         if Surface.surface_type == SurfaceCard.SurfaceType["MACRO_RPP"]:
+            # the order is weird here but so is MCNP
             id = int(Surface.surface_id)
-            self.last_free_surface_index += 1
-            surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " px " + str(Surface.surface_coefficients[0]))
-            new_surf_list.append(surf)
             self.last_free_surface_index += 1
             surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " px " + str(Surface.surface_coefficients[1]))
             new_surf_list.append(surf)
             self.last_free_surface_index += 1
-            surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " py " + str(Surface.surface_coefficients[2]))
+            surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " p -1.0 0 0 " + str(-1.0*Surface.surface_coefficients[0]))
             new_surf_list.append(surf)
             self.last_free_surface_index += 1
             surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " py " + str(Surface.surface_coefficients[3]))
             new_surf_list.append(surf)
             self.last_free_surface_index += 1
-            surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " pz " + str(Surface.surface_coefficients[4]))
+            surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " p 0 -1.0 0 " + str(-1.0*Surface.surface_coefficients[2]))
             new_surf_list.append(surf)
             self.last_free_surface_index += 1
             surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " pz " + str(Surface.surface_coefficients[5]))
             new_surf_list.append(surf)
+            self.last_free_surface_index += 1
+            surf = MCNPSurfaceCard(str(self.last_free_surface_index) + " p 0 0 -1.0 " + str(-1.0*Surface.surface_coefficients[4]))
+            new_surf_list.append(surf)
+            # NOTE new_surf list here is now in MCNP facet order
             # appropriate cell description for inside the macrobody
-            cell_description_inside = "( " + str(new_surf_list[0].surface_id)
+            cell_description_inside = "( -" + str(new_surf_list[0].surface_id)
             cell_description_inside += " -" + str(new_surf_list[1].surface_id)
-            cell_description_inside += " " + str(new_surf_list[2].surface_id)
+            cell_description_inside += " -" + str(new_surf_list[2].surface_id)
             cell_description_inside += " -" + str(new_surf_list[3].surface_id)
-            cell_description_inside += " " + str(new_surf_list[4].surface_id)
+            cell_description_inside += " -" + str(new_surf_list[4].surface_id)
             cell_description_inside += " -" + str(new_surf_list[5].surface_id)
             cell_description_inside += " )"
             # appropriate cell descripiton for outside the macrobody
-            cell_description_outside = "(-" + str(new_surf_list[0].surface_id)
+            cell_description_outside = "( " + str(new_surf_list[0].surface_id)
             cell_description_outside += " : " + str(new_surf_list[1].surface_id)
-            cell_description_outside += " : -" + str(new_surf_list[2].surface_id)
+            cell_description_outside += " : " + str(new_surf_list[2].surface_id)
             cell_description_outside += " : " + str(new_surf_list[3].surface_id)
-            cell_description_outside += " : -" + str(new_surf_list[4].surface_id)
+            cell_description_outside += " : " + str(new_surf_list[4].surface_id)
             cell_description_outside += " : " + str(new_surf_list[5].surface_id)
             cell_description_outside += ")"
             
@@ -535,10 +540,7 @@ class MCNPInput(InputDeck):
             id = int(Surface.surface_id)
             
             vector = [Surface.surface_coefficients[3],Surface.surface_coefficients[4],Surface.surface_coefficients[5]]
-            if vector.count(0) == 2:
-                new_surf_list, cell_description = self.__macro_rcc_cylinder(Surface,vector)                       
-            else:
-                new_surf_list, cell_description = self.__macro_rcc_cylinder_arbitrary(Surface,vector)
+            new_surf_list, cell_description = self.__macro_rcc_cylinder_arbitrary(Surface,vector)
 
         elif Surface.surface_type == SurfaceCard.SurfaceType["MACRO_BOX"]:
 
@@ -561,34 +563,35 @@ class MCNPInput(InputDeck):
             d5 = vec3n[0]*origin[0] + vec3n[1]*origin[1] + vec3n[2]*origin[2]
             d6 = vec3n[0]*(origin[0] + vec3[0]) + vec3n[1]*(origin[1]+vec3[1]) + vec3n[2]*(origin[2]+vec3[2])
 
-            p1 = self.__make_new_plane(vec1n,d1)
-            p2 = self.__make_new_plane(vec1n,d2)
+            
+            # cannonical facet ordering is +ve side the -ve side
+            p1 = self.__make_new_plane(vec1n,d2)
+            p2 = self.__make_new_plane(-1.0*vec1n,d1)
 
-            p3 = self.__make_new_plane(vec2n,d3)
-            p4 = self.__make_new_plane(vec2n,d4)
+            p3 = self.__make_new_plane(vec2n,d4)
+            p4 = self.__make_new_plane(-1.0*vec2n,d3)
 
-            p5 = self.__make_new_plane(vec3n,d5)
-            p6 = self.__make_new_plane(vec3n,d6)
+            p5 = self.__make_new_plane(vec3n,d6)
+            p6 = self.__make_new_plane(-1.0*vec3n,d5)
 
             new_surf_list = [p1,p2,p3,p4,p5,p6]
 
             cell_description_inside = "("
             cell_description_inside +=        str(new_surf_list[0].surface_id)
-            cell_description_inside += " -" + str(new_surf_list[1].surface_id)
+            cell_description_inside += " " + str(new_surf_list[1].surface_id)
             cell_description_inside += " " + str(new_surf_list[2].surface_id)
-            cell_description_inside += " -" + str(new_surf_list[3].surface_id)
+            cell_description_inside += " " + str(new_surf_list[3].surface_id)
             cell_description_inside += " " + str(new_surf_list[4].surface_id)
-            cell_description_inside += " -" + str(new_surf_list[5].surface_id)          
+            cell_description_inside += " " + str(new_surf_list[5].surface_id)          
             cell_description_inside += ")"
 
             cell_description_outside = "("
             cell_description_outside += "-"  + str(new_surf_list[0].surface_id)
-            cell_description_outside += ":" + str(new_surf_list[1].surface_id)
+            cell_description_outside += ":-" + str(new_surf_list[1].surface_id)
             cell_description_outside += ":-"  + str(new_surf_list[2].surface_id)
-            cell_description_outside += ":" + str(new_surf_list[3].surface_id)
+            cell_description_outside += ":-" + str(new_surf_list[3].surface_id)
             cell_description_outside += ":-"  + str(new_surf_list[4].surface_id)
-            cell_description_outside += ":" + str(new_surf_list[5].surface_id)          
-            cell_description_outside += ")"
+            cell_description_outside += ":-" + str(new_surf_list[5].surface_id)          
 
             cell_description = [cell_description_inside,cell_description_outside]
         else:

--- a/python/MaterialCard.py
+++ b/python/MaterialCard.py
@@ -3,6 +3,85 @@
 from Card import Card
 from MaterialData import MaterialData
 
+colours = [0]*71
+colours[0]="0 208 31"
+colours[1]="0 0 255"
+colours[2]="255 255 0"
+colours[3]="0 255 0"
+colours[4]="0 255 255"
+colours[5]="255 164 0"
+colours[6]="255 192 202"
+colours[7]="159 31 239"
+colours[8]="164 42 42"
+colours[9]="111 128 144"
+colours[10]="239 255 255"
+colours[11]="222 184 134"
+colours[12]="126 255 0"
+colours[13]="255 0 255"
+colours[14]="255 126 80"
+colours[15]="255 248 220"
+colours[16]="177 33 33"
+colours[17]="255 214 0"
+colours[18]="239 255 239"
+colours[19]="239 230 139"
+colours[20]="175 47 95"
+colours[21]="218 111 213"
+colours[22]="218 164 31"
+colours[23]="221 159 221"
+colours[24]="255 245 237"
+colours[25]="159 82 44"
+colours[26]="215 190 215"
+colours[27]="255 98 70"
+colours[28]="64 223 208"
+colours[29]="245 222 179"
+colours[30]="249 128 113"
+colours[31]="95 158 159"
+colours[32]="184 133 10"
+colours[33]="84 107 46"
+colours[34]="106 90 205"
+colours[35]="255 139 0"
+colours[36]="153 49 204"
+colours[37]="143 187 143"
+colours[38]="46 79 79"
+colours[39]="255 19 146"
+colours[40]="0 190 255"
+colours[41]="249 235 214"
+colours[42]="255 239 245"
+colours[43]="172 215 230"
+colours[44]="237 221 130"
+colours[45]="255 182 193"
+colours[46]="30 144 255"
+colours[47]="255 159 121"
+colours[48]="134 206 249"
+colours[49]="255 255 223"
+colours[50]="185 84 210"
+colours[51]="175 196 222"
+colours[52]="146 111 219"
+colours[53]="255 69 0"
+colours[54]="151 250 151"
+colours[55]="174 237 237"
+colours[56]="219 111 146"
+colours[57]="223 255 255"
+colours[58]="65 105 224"
+colours[59]="187 143 143"
+colours[60]="134 206 235"
+colours[61]="0 255 126"
+colours[62]="70 130 180"
+colours[63]="255 0 0"
+colours[64]="0 0 0"
+colours[65]="0 0 255"
+colours[66]="191 0 0"
+colours[67]="0 255 0"
+colours[68]="191 0 255"
+colours[69]="255 255 0"
+colours[70]="255 255 255"
+
+# get the mcnp colour for the material
+# this is mostly for automated testing
+def get_material_colour(idx):
+    # this obviously returns the same colour more than once
+    # but this is what MCNP does so we duplicate this behavior
+    return colours[idx%71] 
 
 class MaterialCard(Card):
 
@@ -19,7 +98,8 @@ class MaterialCard(Card):
     xsid_dictionary = {}
     density = 0
     mat_data = 0
-
+    material_colour = 0
+    
     # constructor
     def __init__(self, material_number = 0, card_string = ""):
         Card.__init__(self,card_string)
@@ -30,6 +110,7 @@ class MaterialCard(Card):
         string = "Material: " + self.material_name + "\n"
         string += "Material num: " + str(self.material_number) + "\n"
         string += "Density: " + str(self.density) + "\n"
+        string += "Colour: " + str(self.material_colour)
         string += "Composition \n"
         for item in self.composition_dictionary.keys():
             string += item + " " + str(self.composition_dictionary[item]) + "\n"

--- a/python/OpenMCCell.py
+++ b/python/OpenMCCell.py
@@ -1,8 +1,29 @@
 #/usr/env/python3
 
+import math
+import numpy as np
+
 from CellCard import CellCard
 import xml.etree.ElementTree as ET
 
+def angle_from_rotmatrix(matrix):
+
+    matrix = [float(i) for i in matrix]
+
+    # todo these -1s are guesses
+    theta_r = -1*math.asin(matrix[6])
+    theta = -1*np.rad2deg(theta_r)
+
+    # these -1s are guesses
+    sin_phi = matrix[7]/np.cos(theta_r)
+    phi = -1*np.rad2deg(math.asin(sin_phi))
+
+    # this one makes clite work properly
+    sin_psi = matrix[3] / np.cos(theta_r)
+    psi = -1*np.rad2deg(math.asin(sin_psi))
+
+    return phi,theta,psi
+                     
 # turn the generic operation type into a mcnp relevant text string
 def openmc_op_from_generic(Operation):
     # if we are not of type operator - we are string do nowt
@@ -40,9 +61,14 @@ def get_openmc_cell_info(cell):
 
     if cell.cell_universe_rotation != 0:
         rotation = ""
-        rotation += str(cell.cell_universe_rotation[0]) + " "
-        rotation += str(cell.cell_universe_rotation[4]) + " "
-        rotation += str(cell.cell_universe_rotation[8])
+
+        [phi,theta,psi] = angle_from_rotmatrix(cell.cell_universe_rotation)
+
+        print (cell.cell_id, phi, theta, psi)
+        
+        rotation += str(phi) + " "
+        rotation += str(theta) + " "
+        rotation += str(psi)
     else:
         rotation = "0 0 0"
 

--- a/python/OpenMCSurface.py
+++ b/python/OpenMCSurface.py
@@ -55,6 +55,15 @@ def openmc_surface_info(SurfaceCard):
     elif SurfaceCard.surface_type == SurfaceCard.SurfaceType["CONE_Z"]:
         type_string = "z-cone"
         coeff_string = ' '.join(str(e) for e in SurfaceCard.surface_coefficients)
+    elif SurfaceCard.surface_type == SurfaceCard.SurfaceType["TORUS_X"]:
+        type_string = "torus-x"
+        coeff_string = ' '.join(str(e) for e in SurfaceCard.surface_coefficients)
+    elif SurfaceCard.surface_type == SurfaceCard.SurfaceType["TORUS_Y"]:
+        type_string = "torus-y"
+        coeff_string = ' '.join(str(e) for e in SurfaceCard.surface_coefficients)
+    elif SurfaceCard.surface_type == SurfaceCard.SurfaceType["TORUS_Z"]:
+        type_string = "torus-z"
+        coeff_string = ' '.join(str(e) for e in SurfaceCard.surface_coefficients)
     else:
         type_string = "error"
         coeff_string = "error"

--- a/python/SerpentMaterialCard.py
+++ b/python/SerpentMaterialCard.py
@@ -6,7 +6,10 @@ from MaterialCard import MaterialCard
 def write_serpent_material(filestream, material):
     string = "% " + material.material_name  +"\n"
     string += "mat " + str(material.material_number) + " "
-    string += str(material.density) + "\n"
+    string += str(material.density)
+    # if its a non tally material set the relevant colour
+    if material.material_colour != 0:
+        string += " rgb " + material.material_colour + "\n"
     for nuc in material.composition_dictionary:
         string += '{} {:e} \n'.format(nuc, material.composition_dictionary[nuc])
     filestream.write(string)

--- a/python/SurfaceCard.py
+++ b/python/SurfaceCard.py
@@ -226,12 +226,14 @@ class SurfaceCard(Card):
             self.surface_coefficients[1] = self.surface_coefficients[7]
             self.surface_coefficients[2] = self.surface_coefficients[8]
             self.surface_coefficients[3] = -1.*self.surface_coefficients[9]
+            self.surface_coefficients = self.surface_coefficients[0:4]
             self.surface_type = self.SurfaceType['PLANE_GENERAL']
         elif all( value == 0. for value in self.surface_coefficients[0:7]) :
             self.surface_coefficients[0] = 0.0
             self.surface_coefficients[1] = 0.0
             self.surface_coefficients[2] = 1.0
             self.surface_coefficients[3] = -1.*self.surface_coefficients[9]
+            self.surface_coefficients = self.surface_coefficients[0:4]
             self.surface_type = self.SurfaceType['PLANE_Z']
         else:
             return

--- a/python/test/UnitTestMCNPInput.py
+++ b/python/test/UnitTestMCNPInput.py
@@ -17,21 +17,21 @@ class TestMCNPInputMethods(unittest.TestCase):
         Surface = MCNPSurfaceCard(card_string)
         # explode macrobody into surfaces
         cells, new_surfaces = input.explode_macrobody(Surface)        
-        self.assertEqual(cells[0], "( 1 -2 3 -4 5 -6 )")
-        self.assertEqual(cells[1], "(-1 : 2 : -3 : 4 : -5 : 6)")
+        self.assertEqual(cells[0], "( -1 -2 -3 -4 -5 -6 )")
+        self.assertEqual(cells[1], "( 1 : 2 : 3 : 4 : 5 : 6)")
         self.assertEqual(len(new_surfaces),6)
         self.assertEqual(new_surfaces[0].surface_type,SurfaceCard.SurfaceType["PLANE_X"])
-        self.assertEqual(new_surfaces[0].surface_coefficients[3],-1)
-        self.assertEqual(new_surfaces[1].surface_type,SurfaceCard.SurfaceType["PLANE_X"])
-        self.assertEqual(new_surfaces[1].surface_coefficients[3],1)
+        self.assertEqual(new_surfaces[0].surface_coefficients[3],1)
+        self.assertEqual(new_surfaces[1].surface_type,SurfaceCard.SurfaceType["PLANE_GENERAL"])
+        self.assertEqual(new_surfaces[1].surface_coefficients[0],-1)
         self.assertEqual(new_surfaces[2].surface_type,SurfaceCard.SurfaceType["PLANE_Y"])
-        self.assertEqual(new_surfaces[2].surface_coefficients[3],-1)
-        self.assertEqual(new_surfaces[3].surface_type,SurfaceCard.SurfaceType["PLANE_Y"])
-        self.assertEqual(new_surfaces[3].surface_coefficients[3],1)
+        self.assertEqual(new_surfaces[2].surface_coefficients[3],1)
+        self.assertEqual(new_surfaces[3].surface_type,SurfaceCard.SurfaceType["PLANE_GENERAL"])
+        self.assertEqual(new_surfaces[3].surface_coefficients[1],-1)
         self.assertEqual(new_surfaces[4].surface_type,SurfaceCard.SurfaceType["PLANE_Z"])
-        self.assertEqual(new_surfaces[4].surface_coefficients[3],-1)
-        self.assertEqual(new_surfaces[5].surface_type,SurfaceCard.SurfaceType["PLANE_Z"])
-        self.assertEqual(new_surfaces[5].surface_coefficients[3],1)
+        self.assertEqual(new_surfaces[4].surface_coefficients[3],1)
+        self.assertEqual(new_surfaces[5].surface_type,SurfaceCard.SurfaceType["PLANE_GENERAL"])
+        self.assertEqual(new_surfaces[5].surface_coefficients[2],-1)
 
     def test_flatten_macrobodies(self):
         input_string = ["this is a title\n"]
@@ -53,8 +53,8 @@ class TestMCNPInputMethods(unittest.TestCase):
         cell1 = input.cell_list[0] 
         cell2 = input.cell_list[1] 
 
-        self.assertEqual(cell1.text_string, "1 1 -1.0 ( 4 -5 6 -7 8 -9 )")
-        self.assertEqual(cell2.text_string, "2 0 (-4 : 5 : -6 : 7 : -8 : 9)")
+        self.assertEqual(cell1.text_string, "1 1 -1.0 ( -4 -5 -6 -7 -8 -9 )")
+        self.assertEqual(cell2.text_string, "2 0 ( 4 : 5 : 6 : 7 : 8 : 9)")
 
     def test_flatten_macrobodies_with_other_surfs(self):
         input_string = ["this is a title\n"]
@@ -89,8 +89,8 @@ class TestMCNPInputMethods(unittest.TestCase):
 
         # surface numbering should start at 7
         self.assertEqual(cell3.text_string, "3 0 7")
-        self.assertEqual(cell2.text_string, "2 0 ( 8 -9 10 -11 12 -13 )")
-        self.assertEqual(cell1.text_string, "1 1 -1.0 -7 (-8 : 9 : -10 : 11 : -12 : 13)")
+        self.assertEqual(cell2.text_string, "2 0 ( -8 -9 -10 -11 -12 -13 )")
+        self.assertEqual(cell1.text_string, "1 1 -1.0 -7 ( 8 : 9 : 10 : 11 : 12 : 13)")
 
         # surfaces should be numbered from 7 to 13 contiguously
         for i in range(0,len(input.surface_list)):
@@ -100,11 +100,11 @@ class TestMCNPInputMethods(unittest.TestCase):
         self.assertEqual(input.surface_list[0].surface_type, SurfaceCard.SurfaceType["SPHERE_GENERAL"])
         # 8-9 px 10-11 py 12-13 pz
         self.assertEqual(input.surface_list[1].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
-        self.assertEqual(input.surface_list[2].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
+        self.assertEqual(input.surface_list[2].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[3].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
-        self.assertEqual(input.surface_list[4].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
+        self.assertEqual(input.surface_list[4].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[5].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
-        self.assertEqual(input.surface_list[6].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
+        self.assertEqual(input.surface_list[6].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
 
 
     def test_flatten_macrobodies_with_multiple_macrobodies(self):
@@ -143,31 +143,31 @@ class TestMCNPInputMethods(unittest.TestCase):
 
         # are surfaces correctly processed
         self.assertEqual(input.surface_list[0].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
-        self.assertEqual(input.surface_list[1].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
+        self.assertEqual(input.surface_list[1].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[2].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
-        self.assertEqual(input.surface_list[3].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
+        self.assertEqual(input.surface_list[3].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[4].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
-        self.assertEqual(input.surface_list[5].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
+        self.assertEqual(input.surface_list[5].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
 
         self.assertEqual(input.surface_list[6].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
-        self.assertEqual(input.surface_list[7].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
+        self.assertEqual(input.surface_list[7].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[8].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
-        self.assertEqual(input.surface_list[9].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
+        self.assertEqual(input.surface_list[9].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[10].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
-        self.assertEqual(input.surface_list[11].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
+        self.assertEqual(input.surface_list[11].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
 
         self.assertEqual(input.surface_list[12].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
-        self.assertEqual(input.surface_list[13].surface_type, SurfaceCard.SurfaceType["PLANE_X"])
+        self.assertEqual(input.surface_list[13].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[14].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
-        self.assertEqual(input.surface_list[15].surface_type, SurfaceCard.SurfaceType["PLANE_Y"])
+        self.assertEqual(input.surface_list[15].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
         self.assertEqual(input.surface_list[16].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
-        self.assertEqual(input.surface_list[17].surface_type, SurfaceCard.SurfaceType["PLANE_Z"])
+        self.assertEqual(input.surface_list[17].surface_type, SurfaceCard.SurfaceType["PLANE_GENERAL"])
 
 
         # surface numbering should start at 6
-        self.assertEqual(cell1.text_string, "1 1 -1.0 ( 6 -7 8 -9 10 -11 )")
-        self.assertEqual(cell2.text_string, "2 0 ( -6 : 7 : -8 : 9 : -10 : 11 ) ( 12 -13 14 -15 16 -17 )")
-        self.assertEqual(cell3.text_string, "3 0 ( -12 : 13 : -14 : 15 : -16 : 17 ) ( 18 -19 20 -21 22 -23 )")
+        self.assertEqual(cell1.text_string, "1 1 -1.0 ( -6 -7 -8 -9 -10 -11 )")
+        self.assertEqual(cell2.text_string, "2 0 ( 6 : 7 : 8 : 9 : 10 : 11 ) ( -12 -13 -14 -15 -16 -17 )")
+        self.assertEqual(cell3.text_string, "3 0 ( 12 : 13 : 14 : 15 : 16 : 17 ) ( -18 -19 -20 -21 -22 -23 )")
 
         return
 


### PR DESCRIPTION
This PR fixes issues found with the expansion of macrobodies, due to the fact the MCNP uses the convention that -ve sense refers to the inside of the macrobody, and +ve sense to the outside. What this means in effect, is that when MCNP expands a macrobody (eg RPP into 6 planes) 3 of the planes are regular PX types and the other are general planes with the opposite sense e.g. P -1 0 0 10. This is now correctly taken into account during the expansion and referencing of these macrobody facets. 