### PR TITLE
Remove duplicate surfaces

### DIFF
--- a/csg2csg/CellCard.py
+++ b/csg2csg/CellCard.py
@@ -48,4 +48,34 @@ class CellCard(Card):
         string += "Comment " + str(self.cell_comment) + "\n"
         string += "Text Description " + str(self.cell_text_description) + "\n"
         string += "Cell Description " + str(self.cell_interpreted) + "\n"
+        string += "Surfs in Cell " + str(self.cell_surface_list) + "\n"
         return string
+
+    """ Look for surface new in the list
+    and replace with surface reference
+    """
+    def replace_surface(self,reference_surface,new,reverse):
+        #self.cell_surface_list.remove(reference_surface)
+        #self.cell_surface_list.add(new)
+        print('ref ',reference_surface,' new ',new)
+        # loop over the cell looking for surfaces
+        for idx,item in enumerate(self.cell_interpreted):
+            # if the surface has -ve or +ve sense and doesnt
+            # need reversing just insert it
+            if not isinstance(item, self.OperationType) and item not in {'(',')'}:
+                
+                surf = int(item)
+                if abs(surf) == new and surf == new and not reverse:
+                    print('replacing ',surf,' with ',reference_surface)
+                    self.cell_interpreted[idx] = str(int(reference_surface))
+                elif abs(surf) == new and surf != new and not reverse:
+                   self.cell_interpreted[idx] = str(-1*int(reference_surface))
+                   print('replacing -',surf,' with -',reference_surface)
+                elif abs(surf) == new and surf != new and reverse:
+                    self.cell_interpreted[idx] = str(int(reference_surface))
+                    print('replacing -',surf,' with ',reference_surface)
+                elif abs(surf) == new and surf == new and reverse:
+                    self.cell_interpreted[idx] = str(-1*int(reference_surface))
+                    print('replacing ',surf,' with -',reference_surface)
+        print(self.cell_id, self.cell_interpreted)
+        return

--- a/csg2csg/CellCard.py
+++ b/csg2csg/CellCard.py
@@ -57,19 +57,24 @@ class CellCard(Card):
     def replace_surface(self,reference_surface,new,reverse):
         #self.cell_surface_list.remove(reference_surface)
         #self.cell_surface_list.add(new)
-        print('ref ',reference_surface,' new ',new)
+
         # loop over the cell looking for surfaces
         for idx,item in enumerate(self.cell_interpreted):
             # if the surface has -ve or +ve sense and doesnt
             # need reversing just insert it
             if not isinstance(item, self.OperationType) and item not in {'(',')'}:                
                 surf = int(item)
-                if abs(surf) == new and surf == new and not reverse:
-                    self.cell_interpreted[idx] = str(int(reference_surface))
-                elif abs(surf) == new and surf != new and not reverse:
-                   self.cell_interpreted[idx] = str(-1*int(reference_surface))
-                elif abs(surf) == new and surf != new and reverse:
-                    self.cell_interpreted[idx] = str(int(reference_surface))
-                elif abs(surf) == new and surf == new and reverse:
-                    self.cell_interpreted[idx] = str(-1*int(reference_surface))
+                
+                if abs(surf) == new and surf == new:
+                    if not reverse: 
+                        self.cell_interpreted[idx] = str( int(reference_surface))
+                    else:
+                        self.cell_interpreted[idx] = str(-1*int(reference_surface))
+                
+                elif abs(surf) == new and surf != new:
+                    if not reverse:
+                        self.cell_interpreted[idx] = str( -1*int(reference_surface))
+                    else:
+                        self.cell_interpreted[idx] = str( int(reference_surface))
+               
         return

--- a/csg2csg/CellCard.py
+++ b/csg2csg/CellCard.py
@@ -62,20 +62,14 @@ class CellCard(Card):
         for idx,item in enumerate(self.cell_interpreted):
             # if the surface has -ve or +ve sense and doesnt
             # need reversing just insert it
-            if not isinstance(item, self.OperationType) and item not in {'(',')'}:
-                
+            if not isinstance(item, self.OperationType) and item not in {'(',')'}:                
                 surf = int(item)
                 if abs(surf) == new and surf == new and not reverse:
-                    print('replacing ',surf,' with ',reference_surface)
                     self.cell_interpreted[idx] = str(int(reference_surface))
                 elif abs(surf) == new and surf != new and not reverse:
                    self.cell_interpreted[idx] = str(-1*int(reference_surface))
-                   print('replacing -',surf,' with -',reference_surface)
                 elif abs(surf) == new and surf != new and reverse:
                     self.cell_interpreted[idx] = str(int(reference_surface))
-                    print('replacing -',surf,' with ',reference_surface)
                 elif abs(surf) == new and surf == new and reverse:
                     self.cell_interpreted[idx] = str(-1*int(reference_surface))
-                    print('replacing ',surf,' with -',reference_surface)
-        print(self.cell_id, self.cell_interpreted)
         return

--- a/csg2csg/Input.py
+++ b/csg2csg/Input.py
@@ -6,8 +6,11 @@ class InputDeck:
     from this class
     """
     
-    def __init__(self, filename):
+    """ Constructor
+    """
+    def __init__(self, filename, quick = False):
         self.filename = filename
+        self.quick_process = quick
 
         self.file_lines = ""
         self.title = ""

--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -819,6 +819,9 @@ class MCNPInput(InputDeck):
                 idx += 1
                 break
 
+            card_line = cell_line
+            jdx = idx + 1
+            # scan until we are all done                                                             
 
             card_line = cell_line
             jdx = idx + 1
@@ -831,9 +834,6 @@ class MCNPInput(InputDeck):
                 # mcnp continue line is indicated by 5 spaces
                 if cell_line.startswith("     ") and not cell_line.isspace():
                     card_line += cell_line
-                # we have found a $comment line with nothing before it
-                elif cell_line.isspace() and cell_comment:
-                    pass
                 else: # else we have found a new cell card
                     logging.debug("%s\n", "Found new cell card " + card_line)
                     cellcard = MCNPCellCard(card_line)

--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -10,6 +10,7 @@ from csg2csg.MCNPCellCard import MCNPCellCard, is_cell_card, write_mcnp_cell
 from csg2csg.MCNPSurfaceCard import MCNPSurfaceCard, is_surface_card, write_mcnp_surface
 from csg2csg.MCNPDataCard import MCNPTransformCard
 from csg2csg.MCNPMaterialCard import MCNPMaterialCard, write_mcnp_material
+from csg2csg.ProgressBar import ProgressBar
 
 from collections import Counter
 
@@ -32,8 +33,8 @@ class MCNPInput(InputDeck):
     preserve_xsid = False
 
     # constructor
-    def __init__(self, filename =""):
-        InputDeck.__init__(self,filename)
+    def __init__(self, filename ="", quick = False):
+        InputDeck.__init__(self,filename, quick)
 #        self.process()
 
     # TODO - maybe make a function that aribitrarily extract text
@@ -190,10 +191,14 @@ class MCNPInput(InputDeck):
             break
 
         material = MCNPMaterialCard(mat_num, material_string)
+        logging.debug("%s", "material found on line " + str(material))
+
         # set the colour based on the number of colours
         # but only if its really used rather than a tally
         # multiplier material
-        material.material_colour = get_material_colour(len(self.material_list))
+        if material.density > 0:
+            material.material_colour = get_material_colour(len(self.material_list))
+
         self.material_list[material.material_number] = material
 
         return
@@ -287,6 +292,7 @@ class MCNPInput(InputDeck):
     # overloadable materials
     def __reorganise_materials(self):
         material_density = {}
+    
         for cell in self.cell_list:
             # if the material number already exists
             if cell.cell_material_number in material_density:
@@ -295,11 +301,12 @@ class MCNPInput(InputDeck):
                     material_density[cell.cell_material_number].append(cell.cell_density)
             else:
                 material_density[cell.cell_material_number] = [cell.cell_density]
+
         # remove density 0.0 and material 0
         if 0 in material_density.keys(): del material_density[0]
 
         # maybe void problem
-        if not len(material_density): return
+        if len(material_density) == 0: return
 
         # loop over the material_number density pairs
         for mat in sorted(material_density.keys()):
@@ -884,6 +891,51 @@ class MCNPInput(InputDeck):
             idx = jdx
         return idx
 
+    """ Identify and remove duplicate surfaces
+    """
+    def __remove_duplicate_surfaces(self):
+        # dictionaries to contain the duplicate surfaces
+        # and the senses if needed
+        duplicates = {}
+        senses = {}
+
+        # get a copy of the surface list
+
+        # loop over the surfaces and compare them
+        print('comparing surfaces...')
+        for idx,surf in enumerate(self.surface_list):
+            # compare surfaces against all others
+            # dont compare surfaces that we already have duplicates 
+            # for
+            if surf in duplicates:
+                break
+
+            # build a new list not including the current surf
+            for compare in self.surface_list:
+                if compare == surf:
+                    break
+                
+                # compare surfaces including the reverse
+                (same,reverse) = surf.diff(compare,True)
+                # surface is duplicated
+                if(same):
+                    duplicates[compare] = surf
+                    senses[compare] = reverse
+        
+        # may need to check for surfaces that have multiple
+        # similarities e.g. 3 and 1 are the same and so are
+        # 4 and 1, but I think 3 and 4 would also be recognised
+        # as the same, 
+        
+        # update the cell definition
+        for cell in self.cell_list:
+            # loop over the surface and replace where appropriate
+            for surf in duplicates.keys():
+                # TODO really we should be replacing the surface instance
+                # rather than the id
+                cell.replace_surface(duplicates[surf].surface_id,surf.surface_id,senses[surf])
+        return
+
     # process the mcnp input deck and read into a generic datastructure
     # that we can translate to other formats
     def process(self):
@@ -944,11 +996,21 @@ class MCNPInput(InputDeck):
 
         self.__apply_boundary_conditions() # must be done after explode & flatten
 
-        self.__generate_bounding_coordinates()
         # update the bounding coordinates of surfaces that need it
         # cones for example
+        self.__generate_bounding_coordinates()
+        # update surface definitions that need it
         self.__update_surfaces()
-
+        
+        # if quick processing is on dont remove duplicate surfaces
+        # its rather slow
+        if not self.quick_process:
+            # identify and remove identical surfaces
+            # update cell definition accordingly
+            self.__remove_duplicate_surfaces()
+ 
+        # split complex cells into simple convex solids composed 
+        # of as few peices as possible
         self.split_unions()
 
         return

--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -942,9 +942,9 @@ class MCNPInput(InputDeck):
                         # convert the surface 
                         match = surfs_for_comparison[compare]
                         original = surfs_for_comparison[surf]
-
                         duplicates[match] = original
                         senses[match] = reverse
+                        logging.debug("%s", "Surface %s and Surface %s match with the sense %s" % (match.surface_id, original.surface_id,reverse))
 
 
         """
@@ -988,7 +988,12 @@ class MCNPInput(InputDeck):
             for surf in duplicates.keys():
                 # TODO really we should be replacing the surface instance
                 # rather than the id
-                cell.replace_surface(duplicates[surf].surface_id,surf.surface_id,senses[surf])
+                cell.replace_surface(duplicates[surf].surface_id, surf.surface_id, senses[surf])
+
+        # remove the duplicate surface
+        for surf in duplicates:
+            self.surface_list.remove(surf)
+                
         return
 
     # process the mcnp input deck and read into a generic datastructure

--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -916,11 +916,37 @@ class MCNPInput(InputDeck):
             # generalise the surface - this list is build because
             # generalisation is quite expensive
             new_surf.generalise()
-            surfs_for_comparison[surf] = new_surf
+            surfs_for_comparison[new_surf] = surf
+
+        surf_by_type = {}
+        # segregate surfs for comparison by type
+        for surf in surfs_for_comparison:
+            if surf.surface_type in surf_by_type:
+                surf_by_type[surf.surface_type].append(surf)
+            else:
+                surf_by_type[surf.surface_type] = [surf]
+
+        # loop over the types
+        for type in surf_by_type.keys():
+            # loop over the surfaces of the same type
+            for idx,surf in enumerate(surf_by_type[type]):
+                # loop over surface of the same type
+                for compare in surf_by_type[type]:
+                    # this looks wrong but doesnt do double comparing
+                    if surf == compare:
+                        break
+
+                    # compare surfaces including the reverse
+                    (same,reverse) = surf.diff(compare,True,True)
+                    # surface is duplicated
+                    if(same):
+                        match = surfs_for_comparison[compare]
+                        original = surfs_for_comparison[surf]
+                        duplicates[match] = original
+                        senses[match] = reverse
 
 
-        # segregate surfs for comparison
-        #for surf in surfs_for_comparison:
+        """
 
         num_surf = len(self.surface_list)
 
@@ -948,7 +974,8 @@ class MCNPInput(InputDeck):
                 if(same):
                     duplicates[compare] = surf
                     senses[compare] = reverse
-        
+        """
+
         # may need to check for surfaces that have multiple
         # similarities e.g. 3 and 1 are the same and so are
         # 4 and 1, but I think 3 and 4 would also be recognised

--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -10,7 +10,6 @@ from csg2csg.MCNPCellCard import MCNPCellCard, is_cell_card, write_mcnp_cell
 from csg2csg.MCNPSurfaceCard import MCNPSurfaceCard, is_surface_card, write_mcnp_surface
 from csg2csg.MCNPDataCard import MCNPTransformCard
 from csg2csg.MCNPMaterialCard import MCNPMaterialCard, write_mcnp_material
-from csg2csg.ProgressBar import ProgressBar
 
 from collections import Counter
 
@@ -940,8 +939,10 @@ class MCNPInput(InputDeck):
                     (same,reverse) = surf.diff(compare,True,True)
                     # surface is duplicated
                     if(same):
+                        # convert the surface 
                         match = surfs_for_comparison[compare]
                         original = surfs_for_comparison[surf]
+
                         duplicates[match] = original
                         senses[match] = reverse
 

--- a/csg2csg/MCNPMaterialCard.py
+++ b/csg2csg/MCNPMaterialCard.py
@@ -6,9 +6,12 @@ from csg2csg.MCNPFormatter import get_fortran_formatted_number
 import sys
 
 # writes an mcnp material card given the generic description
-def write_mcnp_material(filestream, Material, preserve_xs):
+def write_mcnp_material(filestream, Material, preserve_xs, write_comment = True):
 
-    filestream.write("C Material " + str(Material.material_name) + "\n")
+    # if you want the comment
+    if write_comment:
+        filestream.write("C Material " + str(Material.material_name) + "\n")
+
     filestream.write("M"+ str(Material.material_number))
     for nucid in Material.composition_dictionary:
         string = "     " + str(nucid)

--- a/csg2csg/PhitsInput.py
+++ b/csg2csg/PhitsInput.py
@@ -52,7 +52,7 @@ class PhitsInput(InputDeck):
     def __write_phits_materials(self, filestream):
         filestream.write("[ M A T E R I A L ]\n")
         for material in self.material_list:
-            write_mcnp_material(filestream, self.material_list[material],True)
+            write_mcnp_material(filestream, self.material_list[material], True, False)
         return
     
     # main write serpent method, depending upon where the geometry

--- a/csg2csg/SurfaceCard.py
+++ b/csg2csg/SurfaceCard.py
@@ -64,6 +64,7 @@ class SurfaceCard(Card):
 
     Surface: An instance of a Surface Class
     both: check the diff of the inverse of the surface - only meaningful for plains
+    already_generalised: surface has already been generalised
 
     Returns: Bool,Bool (surface same, inverse_same)
     e.g. T,F - surface was the same, but it wasnt the inverted one
@@ -71,26 +72,23 @@ class SurfaceCard(Card):
          F,F - surfaces wasnt the same
          F,T - cannot occur
     """
-    def diff(self, Surface, both = True):
-        # copy the surfaces so we dont peturb their state
-        s1 = deepcopy(self)
-        s2 = deepcopy(Surface)
-        
+    def diff(self, surface, both = True, already_generalised = False):        
         # generalise the surfaces
-        s1.generalise()
-        s2.generalise()
+        if not already_generalised:
+            self.generalise()
+            surface.generalise()
         
         # they arent the same type 
-        if ( s2.surface_type is not s1.surface_type):
+        if ( surface.surface_type is not self.surface_type):
             return (False,False)
 
         # they are the same
-        if s2.surface_coefficients == s1.surface_coefficients:
+        if surface.surface_coefficients == self.surface_coefficients:
             return (True,False)
         # comparing the other side
         elif both:
-            s2.reverse()
-            if s2.surface_coefficients == s1.surface_coefficients:
+            surface.reverse()
+            if surface.surface_coefficients == self.surface_coefficients:
                 return (True,True)
             else:
                 return (False,False)

--- a/csg2csg/SurfaceCard.py
+++ b/csg2csg/SurfaceCard.py
@@ -1,6 +1,8 @@
 from csg2csg.Card import Card
 from enum import Enum
 
+from copy import deepcopy
+
 class SurfaceCard(Card):
     """ Class for the storage of the generic SurfaceCard type
     Methods for the generation of flat geometry surface card data
@@ -56,7 +58,56 @@ class SurfaceCard(Card):
         string += "Boundary Condition " + str(self.boundary_condition)+"\n"
         string += "Comment: " + str(self.comment)+"\n"
         return string
+
+    """
+    Provides the diff of two surfaces
+
+    Surface: An instance of a Surface Class
+    both: check the diff of the inverse of the surface - only meaningful for plains
+
+    Returns: Bool,Bool (surface same, inverse_same)
+    e.g. T,F - surface was the same, but it wasnt the inverted one
+         T,T - surface was the same, but it was the inverted one
+         F,F - surfaces wasnt the same
+         F,T - cannot occur
+    """
+    def diff(self, Surface, both = True):
+        # copy the surfaces so we dont peturb their state
+        s1 = deepcopy(self)
+        s2 = deepcopy(Surface)
         
+        # generalise the surfaces
+        s1.generalise()
+        s2.generalise()
+        
+        # they arent the same type 
+        if ( s2.surface_type is not s1.surface_type):
+            return (False,False)
+
+        # they are the same
+        if s2.surface_coefficients == s1.surface_coefficients:
+            return (True,False)
+        # comparing the other side
+        elif both:
+            s2.reverse()
+            if s2.surface_coefficients == s1.surface_coefficients:
+                return (True,True)
+            else:
+                return (False,False)
+        # no matches
+        else:
+            return (False,False)
+
+    """
+    Function to reverse the normal of the surface definition
+
+    modifies the class in place
+    """
+    def reverse(self):
+        surf_coeffs = [i * -1 for i in self.surface_coefficients]
+        self.surface_coefficients = surf_coeffs
+        return
+    
     def set_type(self, surf_id, surf_transform, surf_type, coords):
         self.surface_id = surf_id
         self.surface_transform = surf_transform

--- a/csg2csg/SurfaceCard.py
+++ b/csg2csg/SurfaceCard.py
@@ -246,8 +246,10 @@ class SurfaceCard(Card):
             h = self.surface_coefficients[7]
             j = self.surface_coefficients[8]
             k = self.surface_coefficients[9]
+        elif self.surface_type in {self.SurfaceType['TORUS_X'],self.SurfaceType['TORUS_Y'],self.SurfaceType['TORUS_Z']}:
+            return
         else:
-            print ("could not classify surface", self.surface_id)
+            print ("could not classify surface", self.surface_id, self.surface_type)
 
 
         new_surface_coefficients = [0.]*10

--- a/csg2csg/SurfaceCard.py
+++ b/csg2csg/SurfaceCard.py
@@ -85,13 +85,17 @@ class SurfaceCard(Card):
         # they are the same
         if surface.surface_coefficients == self.surface_coefficients:
             return (True,False)
+
         # comparing the other side
         elif both:
             surface.reverse()
             if surface.surface_coefficients == self.surface_coefficients:
+                surface.reverse()
                 return (True,True)
             else:
+                surface.reverse()
                 return (False,False)
+            
         # no matches
         else:
             return (False,False)

--- a/csg2csg/__main__.py
+++ b/csg2csg/__main__.py
@@ -48,6 +48,10 @@ def main():
                         help = 'Output code selections',
                         default = 'all')
 
+    parser.add_argument('-q','--quick', 
+                        help = 'Perform quick translation, skip surface comparison - model may not transport',
+                        action = "store_true")
+
     # parse the arguments
     args = parser.parse_args(argv)
 
@@ -67,7 +71,7 @@ def main():
 
     if args.format == 'mcnp':
         # read the mcnp input
-        input = MCNPInput(filename)
+        input = MCNPInput(filename,args.quick)
         input.read()
         input.process()
     elif args.format == 'serpent':

--- a/csg2csg/test/UnitTestMCNPInput.py
+++ b/csg2csg/test/UnitTestMCNPInput.py
@@ -345,5 +345,68 @@ class TestMCNPInputRegressions(unittest.TestCase):
 
         del input
 
+    def test_duplicate_surface_without_rot(self):
+        input_string = ["this is a title\n"]
+        input_string.append("1 1 -1.0 -1\n")
+        input_string.append("2 1 -1.0  2\n")
+        input_string.append(" \n")
+        input_string.append("1 px 2.0\n")
+        input_string.append("2 px 2.0\n")
+        input_string.append(" \n")
+        input_string.append("m1 1001 1.0\n")
+        input_string.append("   1002 1.0\n")
+
+        # setup input
+        input = MCNPInput()
+        input.cell_list = []
+        input.file_lines = input_string
+        input.total_num_lines = len(input_string)
+        input.quick_process = False
+        input.process()
+        
+        self.assertEqual(len(input.surface_list),1)
+        
+    def test_duplicate_surface_with_rot(self):
+        input_string = ["this is a title\n"]
+        input_string.append("1 1 -1.0 -1\n")
+        input_string.append("2 1 -1.0  2\n")
+        input_string.append(" \n")
+        input_string.append("1 1 px 2.0\n")
+        input_string.append("2 1 px 2.0\n")
+        input_string.append(" \n")
+        input_string.append("*tr1 0 0.15 0 45 90 45 90 0 90 135 90 45\n")
+        input_string.append("m1 1001 1.0\n")
+        input_string.append("   1002 1.0\n")
+
+        # setup input
+        input = MCNPInput()
+        input.cell_list = []
+        input.file_lines = input_string
+        input.total_num_lines = len(input_string)       
+        input.process()
+        
+        self.assertEqual(len(input.surface_list),1)
+
+    def test_duplicate_surface_with_macro(self):
+        input_string = ["this is a title\n"]
+        input_string.append("1 0  -1\n")
+        input_string.append("2 0  -2\n")
+        input_string.append(" \n")
+        input_string.append("1 px 2.0\n")
+        input_string.append("2 rpp -2 2 -2 2 -2 2\n")
+        input_string.append(" \n")
+        input_string.append("*tr1 0 0.15 0 45 90 45 90 0 90 135 90 45\n")
+        input_string.append("m1 1001 1.0\n")
+        input_string.append("   1002 1.0\n")
+
+        # setup input
+        input = MCNPInput()
+        input.cell_list = []
+        input.file_lines = input_string
+        input.total_num_lines = len(input_string)       
+        input.process()
+        
+        self.assertEqual(len(input.surface_list),6)
+
 if __name__ == '__main__':
     unittest.main()

--- a/csg2csg/test/UnitTestSurface.py
+++ b/csg2csg/test/UnitTestSurface.py
@@ -58,5 +58,52 @@ class SurfaceMethods(unittest.TestCase):
         self.assertEqual(surface.surface_coefficients[2],0.0)
         self.assertEqual(surface.surface_coefficients[3],-10.0)
 
+    # test the surface.generalise() function
+    def test_surface_reverse(self):
+        # first surface
+        surface1 = SurfaceCard('')
+        surface_coefficients = [1.0,0.0,0.0,-10.]
+        transform_id = 0
+        surface_type = surface1.SurfaceType['PLANE_GENERAL']
+        surface_id = 1
+        surface1.set_type(surface_id,transform_id,surface_type,surface_coefficients)
+        surface1.generalise()
+        self.assertEqual(surface1.surface_coefficients[6],-1.0)
+        self.assertEqual(surface1.surface_coefficients[9],-10.0)
+    
+    # test the surface.reverse() function
+    def test_surface_reverse(self):
+        # first surface
+        surface1 = SurfaceCard('')
+        surface_coefficients = [1.0,0.0,0.0,-10.]
+        transform_id = 0
+        surface_type = surface1.SurfaceType['PLANE_GENERAL']
+        surface_id = 1
+        surface1.set_type(surface_id,transform_id,surface_type,surface_coefficients)
+        surface1.generalise()
+        surface1.reverse()
+        self.assertEqual(surface1.surface_coefficients[6],-1.0)
+        self.assertEqual(surface1.surface_coefficients[9],-10.0)
+        
+    def test_surface_two_planes_compare(self):
+        # first surface
+        surface1 = SurfaceCard('')
+        surface_coefficients = [1.0,0.0,0.0,10.]
+        transform_id = 0
+        surface_type = surface1.SurfaceType['PLANE_GENERAL']
+        surface_id = 1
+        surface1.set_type(surface_id,transform_id,surface_type,surface_coefficients)
+
+        # second surface
+        surface2 = SurfaceCard('')
+        surface_coefficients = [-1.0,0.0,0.0,-10.]
+        transform_id = 0
+        surface_type = surface2.SurfaceType['PLANE_GENERAL']
+        surface_id = 2
+        surface2.set_type(surface_id,transform_id,surface_type,surface_coefficients)
+
+        self.assertEqual(surface1.diff(surface2,False),(False,False))
+        self.assertEqual(surface1.diff(surface2),(True,True))
+    
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows the the code to identify duplicate surfaces - a particular problem for MCNP inputs. This is a nessessary step for actually running converted geometries that have duplicated surfaces - i.e. most real ones :) So before I couldn't plot geometries translated into Phits since due to the duplication of surfaces, everything overlapped with everything else, and after this change, plotting works as does the 3D mode.

![jet_xy_1](https://user-images.githubusercontent.com/2439754/68225522-79d30180-0040-11ea-9ec0-3ab63b622d01.png)

and in 3d

![jeta_zoom](https://user-images.githubusercontent.com/2439754/68225555-87888700-0040-11ea-8d83-be24c692a74b.png)

I would like to add a progress bar, since the lookup for matching surfaces can take a little bit, for the JET model it was maybe 2 mins more of runtime, but the C-model geometry takes hours due to the number of overlapping surfaces.

Maybe its time to start getting some C++ wrapped code in here now?

