### PR TITLE
Fix issue identified in hcpb paper

### DIFF
--- a/csg2csg/MCNPMaterialCard.py
+++ b/csg2csg/MCNPMaterialCard.py
@@ -53,6 +53,9 @@ class MCNPMaterialCard(MaterialCard):
             frac = get_fortran_formatted_number(tokens[1])
             tokens.pop(0)
             tokens.pop(0)
-            self.composition_dictionary[nucid] = frac
+            if nucid in self.composition_dictionary.keys():
+                self.composition_dictionary[nucid] += frac
+            else:
+                self.composition_dictionary[nucid] = frac
             self.xsid_dictionary[nucid] = xsid
         return

--- a/csg2csg/test/UnitTestMCNPMaterial.py
+++ b/csg2csg/test/UnitTestMCNPMaterial.py
@@ -34,5 +34,31 @@ class TestMCNPMaterial(unittest.TestCase):
         self.assertEqual(list(matcard.xsid_dictionary.values())[0],'')
         self.assertEqual(list(matcard.xsid_dictionary.values())[1],'31c')
 
+    def test_mcnp_material_with_duplicates(self):
+        string ="29063 2.e-01 \n" + \
+                "29063 1.e-01 \n" + \
+                "29065.31c 3.083000e-01 \n"
+        number = 1
+        name = "M1"
+        matcard = MCNPMaterialCard(number,string)
+
+        self.assertEqual(matcard.material_number,number)
+        self.assertEqual(matcard.material_name,name)
+        self.assertEqual(len(matcard.composition_dictionary),2)
+        
+        self.assertEqual(list(matcard.composition_dictionary.keys())[0],'29063')
+        self.assertEqual(list(matcard.composition_dictionary.keys())[1],'29065')
+        
+        self.assertAlmostEqual(list(matcard.composition_dictionary.values())[0],3.e-01)
+        self.assertEqual(list(matcard.composition_dictionary.values())[1],3.083000e-01)
+        
+        self.assertEqual(len(matcard.xsid_dictionary),2)
+
+        self.assertEqual(list(matcard.xsid_dictionary.keys())[0],'29063')
+        self.assertEqual(list(matcard.xsid_dictionary.keys())[1],'29065')
+
+        self.assertEqual(list(matcard.xsid_dictionary.values())[0],'')
+        self.assertEqual(list(matcard.xsid_dictionary.values())[1],'31c')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Recently a bug was spotted and mentioned in a [publication](https://www.sciencedirect.com/science/article/abs/pii/S0920379620301319?dgcid=author) this bug allowed isotopes to feature multiple times within a material deck.

This PR is an attempt to fix the issue by checking for the isotopes existence when building the MCNP material card.