### PR TITLE
Fix for cell cards with an inline comment in the first line.

### DIFF
--- a/csg2csg/MCNPCellCard.py
+++ b/csg2csg/MCNPCellCard.py
@@ -26,7 +26,7 @@ def is_cell_card(line):
                 return True
     except ValueError:
         return False
-    
+
     cellid = int(cell_card[0])
     mat_num = int(cell_card[1])
     if cellid and mat_num == 0:
@@ -65,21 +65,21 @@ def mcnp_op_from_generic(Operation):
 # write the cell card for a serpent cell given a generic cell card
 def write_mcnp_cell(filestream, CellCard, print_importances = True):
     string = str(CellCard.cell_id) + " "
-    
+
     string += str(CellCard.cell_material_number) + " "
     if CellCard.cell_material_number != 0:
         string += str(CellCard.cell_density) + " "
 
     string += " ( "
-    
+
     # build the cell description
     for item in CellCard.cell_interpreted:
         string += mcnp_op_from_generic(item)
 
-    # TODO make string no longer than 60 chars    
-    string += " ) " 
+    # TODO make string no longer than 60 chars
+    string += " ) "
     string += "\n"
-    
+
     string = re.sub(" +"," ",string)
     string = string.strip()
 
@@ -88,7 +88,7 @@ def write_mcnp_cell(filestream, CellCard, print_importances = True):
 
     if CellCard.cell_fill != 0:
         string += " fill="+CellCard.cell_fill + " "
-        if CellCard.cell_universe_offset != 0 or CellCard.cell_universe_rotation != 0:          
+        if CellCard.cell_universe_offset != 0 or CellCard.cell_universe_rotation != 0:
             # universe may have no traslation?
             string += "("
             if CellCard.cell_universe_offset != 0:
@@ -96,14 +96,14 @@ def write_mcnp_cell(filestream, CellCard, print_importances = True):
                     string += str(CellCard.cell_universe_offset[i]) + " "
             else:
                 string += " 0 0 0 "
-    
+
             if CellCard.cell_universe_rotation != 0:
                 for i in range(9):
                     value = float(CellCard.cell_universe_rotation[i])
-                    #value = math.cos(value/180.*math.pi) 
+                    #value = math.cos(value/180.*math.pi)
                     string += str(value) + " "
             string += ")"
-    
+
     if print_importances:
         string += " IMP:N=" + str(CellCard.cell_importance)
 
@@ -134,16 +134,16 @@ class MCNPCellCard(CellCard):
 
     # method to break mcnp cell definition into something
     # a mere mortal can understand turns mcnp description
-    # like 2 3 -4 into 2 AND 3 AND -4 or even 2 AND 3 AND 
+    # like 2 3 -4 into 2 AND 3 AND -4 or even 2 AND 3 AND
     # +4
     def generalise(self):
-        
+
         cell_description = self.cell_text_description
         # wholesale replace + signs as they are implicit
         # print(cell_description)
         # cell_description = [ s = "" for item in cell_description if item == "+"]
         cell_description = list(cell_description)
-    
+
         idx = 0
         while True:
             s = cell_description[idx]
@@ -166,13 +166,13 @@ class MCNPCellCard(CellCard):
                     self.cell_surface_list.add(surf_num)
                 except:
                     pass # its means it was a macrobody
-                
+
             idx += 1
             if idx == len(cell_description): break
 
-        self.cell_interpreted = cell_description  
-        #print(self.cell_id) 
-        #print(self.cell_interpreted) 
+        self.cell_interpreted = cell_description
+        #print(self.cell_id)
+        #print(self.cell_interpreted)
         #logging.debug("%s\n", "Generalised cell card " + ''.join([str(i) for i in self.cell_interpreted]))
 
         return
@@ -186,10 +186,10 @@ class MCNPCellCard(CellCard):
     # given a valid keyword and string return the value of the
     # keyword
     def __get_keyword_value(self,keyword,string):
-        #regex = re.regex=re.compile("("+keyword+") ?= ?[1-9][0-9]*") 
+        #regex = re.regex=re.compile("("+keyword+") ?= ?[1-9][0-9]*")
         regex = re.regex=re.compile("("+keyword+") ?= ?(?=.)([+-]?([0-9]*)(\.([0-9]+))?)")
         result = regex.search(string)[0]
-        return result.split(" ")[2] #string[offset:end]  
+        return result.split(" ")[2] #string[offset:end]
 
     def __extract_string_between(self, string, first_substring, second_substring):
         #print(string, first_substring, second_substring,string.find(first_substring),string.find(second_substring))
@@ -201,9 +201,9 @@ class MCNPCellCard(CellCard):
             return ""
         return result
 
-    # look through the string for the keywords 
+    # look through the string for the keywords
     def __detect_keywords(self, keywords, string):
-        
+
         # loop over the keywords and test
         found_keyword = False
         for word in keywords:
@@ -213,23 +213,23 @@ class MCNPCellCard(CellCard):
         if not found_keyword:
             return string
 
-        # 
+        #
         posd = string.find('$')
         if posd != -1:
             string = string[:posd]
-            
+
         # otherwise loop through and find
         # u= , fill=, imp and tmp:
         posu = string.find("u")
         posf = string.find("fill")
         post = string.find("tmp")
-   
+
         # universe fill angle could be specified in degrees
         rot_angle_degrees = False
         if string.find("*fill") != -1:
             rot_angle_degrees = True
             posf -= 1
-        
+
         posi = string.find("imp")
         posv = string.find("vol")
 
@@ -251,7 +251,7 @@ class MCNPCellCard(CellCard):
             self.cell_universe = 0
         else:
             self.cell_universe = self.__get_keyword_value('u',end_of_string)
-            
+
         if posf == -1:
             self.cell_fill = 0
         else:
@@ -264,24 +264,23 @@ class MCNPCellCard(CellCard):
                 rot_trans = "0"
 
             self.__set_universe_transform(rot_trans,rot_angle_degrees)
- 
+
         if posi == -1:
             self.cell_importance = 1.
         else:
             self.cell_importance = float(self.__get_keyword_value('imp:n',end_of_string))
 
-        # return the string upto the posisiotn of the first detected keyword          
+        # return the string upto the posisiotn of the first detected keyword
         return string[:m]
-    
+
     # populute the part CellCard into its
     # consituent parts
     def __interpret(self):
 
         string = self.text_string
-
         # look for mcnp cell specific keywords
         string = self.__detect_keywords(mcnp_cell_keywords,string)
-        
+
         # this is to detect the presence of any importance
         # values only need one - used to indentify the
         # graveyard
@@ -313,7 +312,7 @@ class MCNPCellCard(CellCard):
             self.cell_density = 0.
             self.cell_material_number = 0
             self.cell_text_description = tokens[2:]
-            
+
         # now interpret the cell text description
         if not self.__is_sanitised():
             self.__sanitise()
@@ -321,7 +320,7 @@ class MCNPCellCard(CellCard):
 
         return
 
-    # set the universe transform 
+    # set the universe transform
     # angle
     def __set_universe_transform(self, transform, angle_form_degrees):
         tokens = transform.split()
@@ -352,9 +351,9 @@ class MCNPCellCard(CellCard):
         # reset the transform
         self.cell_universe_transformation_id = "0"
 
-    # update an existing cell description with 
+    # update an existing cell description with
     def update(self,new_cell_description):
-        # take the new cell description and make a new 
+        # take the new cell description and make a new
         # cell description
         self.text_string = str(self.cell_id)
         self.text_string += " " + str(self.cell_material_number)
@@ -363,7 +362,6 @@ class MCNPCellCard(CellCard):
         else:
             self.text_string += " " + str(self.cell_density)
             self.text_string += " " + new_cell_description
-        
+
         self.__interpret()
-        
-        
+

--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -14,8 +14,8 @@ from csg2csg.MCNPMaterialCard import MCNPMaterialCard, write_mcnp_material
 from collections import Counter
 
 from numpy import linalg as np
-from numpy import dot 
-from numpy import cross 
+from numpy import dot
+from numpy import cross
 from numpy import inf as npinf
 from numpy import around as nparound
 
@@ -27,7 +27,7 @@ import sys
 import re
 
 class MCNPInput(InputDeck):
-    """ MCNPInputDeck class - does the actuall processing 
+    """ MCNPInputDeck class - does the actuall processing
     """
     preserve_xsid = False
 
@@ -74,11 +74,11 @@ class MCNPInput(InputDeck):
                     repeat = int(value.replace("r","")) - 1
                     # this is safe since r cannot be the first
                     # value in the list
-                    last_importance = importance_list[idx-1]  
+                    last_importance = importance_list[idx-1]
                     to_insert = [last_importance]*repeat
                     importance_list[idx] = ' '.join(str(e) for e in to_insert)
             # flatten the list
-            self.importance_list[particle] = ' '.join(str(e) for e in importance_list)         
+            self.importance_list[particle] = ' '.join(str(e) for e in importance_list)
 
         return
 
@@ -96,10 +96,10 @@ class MCNPInput(InputDeck):
             # check for importance keyword
             if "imp" in self.file_lines[idx]:
                 particle = self.file_lines[idx].split()[0].split(":")[1]
-               
-                # TODO mcnp allows the following forms imp:n imp:n,p etc 
+
+                # TODO mcnp allows the following forms imp:n imp:n,p etc
                 particle = mcnpToParticle(particle)
-                logging.debug("%s", "found importance statement for particle " + 
+                logging.debug("%s", "found importance statement for particle " +
                               particleToGeneric(particle) + " on line" + str(idx))
 
                 self.importance_list[particle] = self.file_lines[idx][5:].rstrip()
@@ -113,7 +113,7 @@ class MCNPInput(InputDeck):
                     continue
             else:
                 # otherwise advance the line by one
-                idx += 1        
+                idx += 1
 
         return
 
@@ -122,7 +122,7 @@ class MCNPInput(InputDeck):
     Supports at least two forms of reading weight
     window information
 
-    1) a wwe card 
+    1) a wwe card
     """
     def __get_weight_windows(self, start_line):
         return
@@ -146,7 +146,7 @@ class MCNPInput(InputDeck):
 
             if "tr" in self.file_lines[line]:
                 self.__make_transform_card(self.file_lines[line])
-                
+
             line += 1
         return
 
@@ -158,9 +158,9 @@ class MCNPInput(InputDeck):
         mat_num = tokens[0]
         mat_num = mat_num.replace("m","")
         # set the material number
-        
+
         # rebuild the first mat string
-        material_string = ' '.join(tokens[1:]) + " " 
+        material_string = ' '.join(tokens[1:]) + " "
         if '$' in material_string:
             pos = material_string.find('$')
             material_string = material_string[:pos]
@@ -184,7 +184,7 @@ class MCNPInput(InputDeck):
                         line = line[:pos]
                     material_string += line
                 else: # else we have found a new cell card
-                    break 
+                    break
                 # increment the line that we are looking at
                 idx += 1
             break
@@ -195,7 +195,7 @@ class MCNPInput(InputDeck):
         # multiplier material
         material.material_colour = get_material_colour(len(self.material_list))
         self.material_list[material.material_number] = material
-                
+
         return
 
     # get the material cards definitions
@@ -218,7 +218,7 @@ class MCNPInput(InputDeck):
 
     # get the material cards definitions
     def __get_transform_cards(self, start_line):
-        idx = start_line     
+        idx = start_line
         while True:
             #cell_line = self.file_lines[jdx]
             if idx == len(self.file_lines):
@@ -233,13 +233,13 @@ class MCNPInput(InputDeck):
                     logging.debug("%s", "trn card has continue line " + str(idx))
                     card_line += self.file_lines[idx]
                     idx += 1
-                idx -=1 
+                idx -=1
                 self.__make_transform_card(card_line)
                 card_line = ""
             idx += 1
         return
 
-        
+
         while True:
             if idx == len(self.file_lines):
                 break
@@ -270,10 +270,10 @@ class MCNPInput(InputDeck):
             if cell.cell_universe_transformation_id is not "0":
                 # apply the transform
                 cell.apply_universe_transform(self.transform_list[cell.cell_universe_transformation_id])
-                
 
-    # find the next free material number 
-    def __next_free_int(self):  
+
+    # find the next free material number
+    def __next_free_int(self):
         idx = 1
         while True:
             if str(idx) in self.material_list.keys():
@@ -282,7 +282,7 @@ class MCNPInput(InputDeck):
                 break
         return str(idx)
 
-    # reorganise materials such that we get a new set of unique 
+    # reorganise materials such that we get a new set of unique
     # material number/ density pairs - this to avoid mcnp's
     # overloadable materials
     def __reorganise_materials(self):
@@ -361,11 +361,11 @@ class MCNPInput(InputDeck):
 
         # form the gq quadratic terms
         gq_coeffs[0] = 1. - axis_vector[0]**2
-        gq_coeffs[1] = 1. - axis_vector[1]**2        
-        gq_coeffs[2] = 1. - axis_vector[2]**2 
+        gq_coeffs[1] = 1. - axis_vector[1]**2
+        gq_coeffs[2] = 1. - axis_vector[2]**2
         # form the rotational terms
-        gq_coeffs[3] = -2.*axis_vector[0]*axis_vector[1]        
-        gq_coeffs[4] = -2.*axis_vector[1]*axis_vector[2]        
+        gq_coeffs[3] = -2.*axis_vector[0]*axis_vector[1]
+        gq_coeffs[4] = -2.*axis_vector[1]*axis_vector[2]
         gq_coeffs[5] = -2.*axis_vector[0]*axis_vector[2]
         # form the linear offset terms
         gq_coeffs[6] =  -Surface.surface_coefficients[1]*gq_coeffs[3] \
@@ -413,7 +413,7 @@ class MCNPInput(InputDeck):
         # plane offset 2
         d2 =   axis_vector[0]*(Surface.surface_coefficients[0] + vector[0]) \
              + axis_vector[1]*(Surface.surface_coefficients[1] + vector[1]) \
-             + axis_vector[2]*(Surface.surface_coefficients[2] + vector[2]) 
+             + axis_vector[2]*(Surface.surface_coefficients[2] + vector[2])
 
         self.last_free_surface_index += 1
         surface_string = str(self.last_free_surface_index) + " p "
@@ -461,11 +461,11 @@ class MCNPInput(InputDeck):
             cylinder = " c/x "
             c1 = Surface.surface_coefficients[1]
             c2 = Surface.surface_coefficients[2]
-            top = Surface.surface_coefficients[3] + Surface.surface_coefficients[0] 
+            top = Surface.surface_coefficients[3] + Surface.surface_coefficients[0]
             bottom = Surface.surface_coefficients[0]
 
 
-        # if coefficients 4 & 5 are zero then its a cz with planes at 
+        # if coefficients 4 & 5 are zero then its a cz with planes at
         self.last_free_surface_index += 1
         surf = MCNPSurfaceCard(str(self.last_free_surface_index) + cylinder +
                                 str(c1) + " " +
@@ -539,19 +539,19 @@ class MCNPInput(InputDeck):
             cell_description_outside += " : " + str(new_surf_list[4].surface_id)
             cell_description_outside += " : " + str(new_surf_list[5].surface_id)
             cell_description_outside += ")"
-            
+
             cell_description = [cell_description_inside,cell_description_outside]
-            
+
         elif Surface.surface_type == SurfaceCard.SurfaceType["MACRO_RCC"]:
             id = int(Surface.surface_id)
-            
+
             vector = [Surface.surface_coefficients[3],Surface.surface_coefficients[4],Surface.surface_coefficients[5]]
             new_surf_list, cell_description = self.__macro_rcc_cylinder_arbitrary(Surface,vector)
 
         elif Surface.surface_type == SurfaceCard.SurfaceType["MACRO_BOX"]:
 
             id = int(Surface.surface_id)
-            
+
             origin = [Surface.surface_coefficients[0], Surface.surface_coefficients[1], Surface.surface_coefficients[2]]
 
             vec1 = [Surface.surface_coefficients[3], Surface.surface_coefficients[4], Surface.surface_coefficients[5]]
@@ -562,14 +562,14 @@ class MCNPInput(InputDeck):
             vec2n = vec2/np.norm(vec2)
             vec3n = vec3/np.norm(vec3)
 
-            d1 = vec1n[0]*origin[0] + vec1n[1]*origin[1] + vec1n[2]*origin[2] 
+            d1 = vec1n[0]*origin[0] + vec1n[1]*origin[1] + vec1n[2]*origin[2]
             d2 = vec1n[0]*(origin[0] + vec1[0]) + vec1n[1]*(origin[1]+vec1[1]) + vec1n[2]*(origin[2]+vec1[2])
             d3 = vec2n[0]*origin[0] + vec2n[1]*origin[1] + vec2n[2]*origin[2]
             d4 = vec2n[0]*(origin[0] + vec2[0]) + vec2n[1]*(origin[1]+vec2[1]) + vec2n[2]*(origin[2]+vec2[2])
             d5 = vec3n[0]*origin[0] + vec3n[1]*origin[1] + vec3n[2]*origin[2]
             d6 = vec3n[0]*(origin[0] + vec3[0]) + vec3n[1]*(origin[1]+vec3[1]) + vec3n[2]*(origin[2]+vec3[2])
 
-            
+
             # cannonical facet ordering is done such that the surfaces
             # making up the macrobody all point inwards
             p1 = self.__make_new_plane(vec1n,d2)
@@ -589,7 +589,7 @@ class MCNPInput(InputDeck):
             cell_description_inside += " -" + str(new_surf_list[2].surface_id)
             cell_description_inside += " -" + str(new_surf_list[3].surface_id)
             cell_description_inside += " -" + str(new_surf_list[4].surface_id)
-            cell_description_inside += " -" + str(new_surf_list[5].surface_id)          
+            cell_description_inside += " -" + str(new_surf_list[5].surface_id)
             cell_description_inside += ")"
 
             cell_description_outside = "("
@@ -598,17 +598,17 @@ class MCNPInput(InputDeck):
             cell_description_outside += ":"  + str(new_surf_list[2].surface_id)
             cell_description_outside += ":" + str(new_surf_list[3].surface_id)
             cell_description_outside += ":"  + str(new_surf_list[4].surface_id)
-            cell_description_outside += ":" + str(new_surf_list[5].surface_id)          
+            cell_description_outside += ":" + str(new_surf_list[5].surface_id)
             cell_description_outside += ")"
-            
+
             cell_description = [cell_description_inside,cell_description_outside]
         else:
             warnings.warn('Found an unsupported macrobody, files will not be correct',Warning)
             cell_description = ["",""]
-            
+
         return cell_description, new_surf_list
 
-    # if we find a macrobody in the surface list 
+    # if we find a macrobody in the surface list
     # explode it into a surface based definition
     def __flatten_macrobodies(self):
         # look through the list until we find
@@ -639,14 +639,14 @@ class MCNPInput(InputDeck):
                     while True:
                         # cell text description is contually updated
                         cell_text_description = cell.cell_text_description
-                        
+
                         # if we find the surface id of the macrobdy in the text description
                         sub = str(surf.surface_id)
                         regex = re.compile("^-?("+str(surf.surface_id)+")(\.+[1-9])?$")
                         matches = [m.group(0) for l in cell_text_description for m in [regex.search(l)] if m]
                         #if str(surf.surface_id) in cell_text_description or str(surf.surface_id)+"." in cell_text_description:
-                        
-                        if matches:                       
+
+                        if matches:
                             # loop over each component and find the macrobody
                             for idx, surface in enumerate(cell.cell_text_description):
                                 # if it matches we have the simmple form
@@ -655,9 +655,9 @@ class MCNPInput(InputDeck):
                                     cell.cell_text_description[idx] = cell_description[1]
                                 elif "-"+str(surf.surface_id) == surface:
                                     cell.cell_text_description[idx] = cell_description[0]
-                   
+
                                 # else we have the facet form
-                                if str(surf.surface_id)+"." in surface:                                    
+                                if str(surf.surface_id)+"." in surface:
                                     surface_index = int(surface.split(".")[1]) # get just the mcnp surface index
                                     new_surface_id = new_surfaces[surface_index-1].surface_id # mcnp numbers them 1->n
                                     if "-" in surface: # need to take care of the -sign
@@ -669,7 +669,7 @@ class MCNPInput(InputDeck):
                     # update the text description
                     text_string = ' '.join(cell.cell_text_description)
                     self.cell_list[jdx].update(text_string)
-                
+
         # clear up removed surfaces
         logging.debug("%s", "Deleting macrobody surfaces")
         for surf in to_remove:
@@ -690,12 +690,12 @@ class MCNPInput(InputDeck):
     def __split_nots(self,cell):
         # if the cell has a not in it
         pos = 0
-        count = 0 
+        count = 0
         # loop over the constituents of the cell
         # we have to do this rookie looking stuff
         # because cell.OperationType is not iterable
         for i in cell.cell_interpreted:
-            # if its not an operation 
+            # if its not an operation
             if not isinstance(i,cell.OperationType):
                 if "#" in  i:
                     pos = count
@@ -715,17 +715,17 @@ class MCNPInput(InputDeck):
         # build the cell into the interpreted form
         cell_text = [cell.OperationType(2)] + ["("] + cell_text
         cell_text = cell_text + [")"]
-        
+
         # remove the #cell and insert the full new form
         cell_part = cell.cell_interpreted[:pos]
-        
+
         cell_part.extend(cell_text)
         cell_part2 = cell.cell_interpreted[pos+1:]
         cell_part.extend(cell_part2)
         cell.cell_interpreted = cell_part
 
         return
-        
+
     # loop through the cells and insert
     # cell definititons where needed
     # assuming that we have nots of the form #33 #44 and
@@ -735,9 +735,9 @@ class MCNPInput(InputDeck):
             while self.__nots_remaining(cell):
                 self.__split_nots(cell)
             continue
-            
 
-    # generate bounding coordinates 
+
+    # generate bounding coordinates
     def __generate_bounding_coordinates(self):
         # loop through the surfaces and generate the bounding coordinates
         # condisder only manifold or simple infinite surfaces, like planes
@@ -755,11 +755,11 @@ class MCNPInput(InputDeck):
                 self.bounding_coordinates[4] = box[4]
             if box[5] > self.bounding_coordinates[5]:
                 self.bounding_coordinates[5] = box[5]
-        logging.debug("%s ", "bounding box of geometry is " + str(self.bounding_coordinates[0]) + " " + 
+        logging.debug("%s ", "bounding box of geometry is " + str(self.bounding_coordinates[0]) + " " +
                       str(self.bounding_coordinates[1]) + " " +
-                      str(self.bounding_coordinates[2]) + " " + 
-                      str(self.bounding_coordinates[3]) + " " + 
-                      str(self.bounding_coordinates[4]) + " " + 
+                      str(self.bounding_coordinates[2]) + " " +
+                      str(self.bounding_coordinates[3]) + " " +
+                      str(self.bounding_coordinates[4]) + " " +
                       str(self.bounding_coordinates[5]) + "\n")
 
     # update surfaces that need their bounding coordinates updated
@@ -781,54 +781,64 @@ class MCNPInput(InputDeck):
                     pass
         return
 
+    # remove inline comment and return the new line
+    def __remove_inline_comment(self, cell_line):
+        if "$" in cell_line:
+            pos_comment = cell_line.find("$")
+            cell_comment = cell_line[pos_comment:]
+            line_out = cell_line[:pos_comment]
+
+            # debug output
+            if line_out.isspace() and cell_comment:
+                print(line_out,cell_comment, line_out.isspace(), cell_comment.isspace())
+            return line_out
+        else:
+            return cell_line
+
     # extract all the cell cards
     def __get_cell_cards(self):
         # line by line insert into dictionary of cell descriptions
         # until we find a blank line
         idx = 0
         while True:
+            # remove inline comment ($) if needed
+            self.file_lines[idx] = self.__remove_inline_comment(self.file_lines[idx])
             cell_line = self.file_lines[idx]
+
             # this relies upon us checking correctly for all other
-            # cases where there may be blank lines due to our 
+            # cases where there may be blank lines due to our
             # processing of the string
             if cell_line.isspace():
                 logging.info('%s',"found end of cell cards at line " + str(idx))
                 idx += 1
                 break
 
+
             card_line = cell_line
             jdx = idx + 1
-            # scan until we are all done
+            # scan lines until a complete cell card is created
             while True:
+                # remove inline comment ($) if needed
+                self.file_lines[jdx] = self.__remove_inline_comment(self.file_lines[jdx])
                 cell_line = self.file_lines[jdx]
-                pos_comment = cell_line.find("$")
-                cell_comment = ""
-                if pos_comment != -1:
-                    cell_line = cell_line[:pos_comment]
-                    cell_comment = self.file_lines[jdx][pos_comment:] # set the comment 
-                    self.file_lines[jdx] = cell_line # update the file data
-                    
+
                 # mcnp continue line is indicated by 5 spaces
-                if cell_line[0:5] == "     " and not cell_line.isspace():
+                if cell_line.startswith("     ") and not cell_line.isspace():
                     card_line += cell_line
-                # we have found a $comment line with nothing before it
-                elif cell_line.isspace() and cell_comment:
-                    print(cell_line,cell_comment, cell_line.isspace(), cell_comment.isspace())
-                    pass
                 else: # else we have found a new cell card
                     logging.debug("%s\n", "Found new cell card " + card_line)
                     cellcard = MCNPCellCard(card_line)
                     # we should set the comment here
                     self.cell_list.append(cellcard)
-                    break 
+                    break
                 jdx += 1
-            idx = jdx                   
+            idx = jdx
         return idx
 
     # set the boundary conditions
     def __apply_boundary_conditions(self):
-        
-        # apply the importances to cells 
+
+        # apply the importances to cells
         if len(self.importance_list) != 0:
             # TODO make this loop apply to multiple particle
             # types but for now just do neutrons
@@ -837,10 +847,10 @@ class MCNPInput(InputDeck):
                 for idx,value in enumerate(importances):
                     self.cell_list[idx].cell_importance = float(value)
 
-        # loop over the cells and if the cell has 
+        # loop over the cells and if the cell has
         # importance 0, all the sufaces get boundary
-        # condition 
-        for cell in self.cell_list: 
+        # condition
+        for cell in self.cell_list:
             if cell.cell_importance == 0:
                 for surf in cell.cell_surface_list:
                     self.get_surface_with_id(surf).boundary_condition = SurfaceCard.BoundaryCondition["VACUUM"]
@@ -867,11 +877,11 @@ class MCNPInput(InputDeck):
                     surfacecard = MCNPSurfaceCard(surf_card)
                     self.surface_list.append(surfacecard)
                     # update the surface index counter
-                    if surfacecard.surface_id > self.last_free_surface_index: 
+                    if surfacecard.surface_id > self.last_free_surface_index:
                         self.last_free_surface_index = surfacecard.surface_id
-                    break 
+                    break
                 jdx += 1
-            idx = jdx                  
+            idx = jdx
         return idx
 
     # process the mcnp input deck and read into a generic datastructure
@@ -894,7 +904,7 @@ class MCNPInput(InputDeck):
             logging.debug("%s", "Input Echo")
             for idx,line in enumerate(self.file_lines):
                 logging.debug("%i %s",idx,line)
-            
+
 
         # get the cell cards
         idx = self.__get_cell_cards()
@@ -912,14 +922,14 @@ class MCNPInput(InputDeck):
         # also idx will never be advanced from this point
 
         # try to get importances defined in the data block
-        self.__get_importances(idx)  
+        self.__get_importances(idx)
         # try to get weights defined the data block
         self.__get_weight_windows(idx)
 
         self.__get_transform_cards(idx)
         self.__get_material_cards(idx)
-        # need to flatten first to get transformed surface in the 
-        # correct place 
+        # need to flatten first to get transformed surface in the
+        # correct place
         self.__flatten_macrobodies()
         self.__explode_nots()
 
@@ -940,10 +950,10 @@ class MCNPInput(InputDeck):
         self.__update_surfaces()
 
         self.split_unions()
-       
+
         return
 
-    # perhaps these write functions should actually build strings 
+    # perhaps these write functions should actually build strings
     # and then write at once?
     # write all surfaces to mcnp format
     def __write_mcnp_surfaces(self, filestream):
@@ -973,5 +983,5 @@ class MCNPInput(InputDeck):
         self.__write_mcnp_surfaces(f)
         self.__write_mcnp_materials(f)
         f.close()
-        
-    
+
+


### PR DESCRIPTION
Found this when converting a file with an inline comment after the first line in the cell deck followed by a continuation line.
 
Input deck:

```
   21  133 0.06000038   310  -311          10    30    $ Comment
                      90309 90209 90108 91608 91508    $ Comment
                        97  -203     imp:n=1           $ Comment
```

If this is the case, the code block for removing the inline comment isn't run and that comment ends up in the string passed to the `MCNPCellCard` constructor, where the continuation lines are considered part of the comment and removed. 

Problematic string passed to the `MCNPCellCard` constructor:

`"21  133 0.06000038   310  -311 10    30    $ Comment 90309 90209 90108 91608 91508 97  -203     imp:n=1"`

These changes add a `MCNPInputDeck.__remove_inline_comment()` method which checks for inline comments in both the inner and outer `while` loops of the `MCNPInputDeck.__get_cell_cards()` method.


