### PR TITLE
csg2csg as entry point

### DIFF
--- a/csg2csg/__main__.py
+++ b/csg2csg/__main__.py
@@ -7,7 +7,7 @@ from csg2csg.FLUKAInput import FLUKAInput
 from csg2csg.PhitsInput import PhitsInput
 
 # for debug info
-import logging, sys 
+import logging, sys
 import argparse
 import os
 
@@ -16,39 +16,41 @@ import os
 def mkdir(directory):
     try:
         os.mkdir(directory)
-    except: 
+    except:
         pass
 
 # the main worker
-def main(argv):
+def main():
+
+    argv = sys.argv[1:]
 
     parser = argparse.ArgumentParser(description='csg conversion tool.')
 
-    parser.add_argument('-d','--debug', 
+    parser.add_argument('-d','--debug',
                         help = 'Turn on debug logging',
                         action="store_true")
 
-    parser.add_argument('-i','--input', 
+    parser.add_argument('-i','--input',
                         help = 'Filename to read in',
                         required=True)
 
-    parser.add_argument('-f','--format', 
+    parser.add_argument('-f','--format',
                         choices=["mcnp","serpent","openmc","phits","fluka"],
-                        help = 'format of the input file', 
+                        help = 'format of the input file',
                         default = 'mcnp')
 
-    parser.add_argument('-p','--preserve', 
+    parser.add_argument('-p','--preserve',
                         help = 'Preserve existing cross section id numbers on write',
                         action = "store_true")
-    
-    parser.add_argument('-o','--output', 
+
+    parser.add_argument('-o','--output',
                         nargs='+',
                         help = 'Output code selections',
                         default = 'all')
 
     # parse the arguments
     args = parser.parse_args(argv)
-      
+
     # if debugging requested
     if args.debug:
         logging.basicConfig(filename="csg2csg.log", level=logging.DEBUG)
@@ -56,7 +58,7 @@ def main(argv):
     logging.info("Started")
 
     filename = args.input
-    
+
 
     if "all" in args.output:
         codes = ["mcnp","serpent","openmc","phits","fluka"]
@@ -72,7 +74,7 @@ def main(argv):
         # read the serpent input
         input = SerpentInput(filename)
         input.read()
-        input.process()        
+        input.process()
     elif args.format == 'openmc':
         raise NotImplementedError('OpenMC input files are not supported yet')
     elif args.format == 'phits':
@@ -111,9 +113,9 @@ def main(argv):
             fluka.from_input(input)
             mkdir("fluka")
             fluka.write_fluka("fluka/fluka.inp")
-    
+
     logging.info("Finshed")
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
-    
+    main()
+

--- a/csg2csg/test/integration/TestWindowsLineEndings.py
+++ b/csg2csg/test/integration/TestWindowsLineEndings.py
@@ -3,13 +3,13 @@
 import unittest
 import subprocess
 
-class TestWindowsLineEndings(unittest.TestCase):   
+class TestWindowsLineEndings(unittest.TestCase):
     def test_windows_line_endings(self):
 
-        return_code = subprocess.call("python3 ../../csg2csg -i files/spheres.i -f mcnp -o all", shell=True)  
+        return_code = subprocess.call("csg2csg -i files/spheres.i -f mcnp -o all", shell=True)
         self.assertEqual(return_code,0)
         return_code = subprocess.call("sed -e 's/$/\r/' files/spheres.i > spheres_win.i                # UNIX to DOS  (adding CRs)", shell=True)
-        return_code = subprocess.call("python3 ../../csg2csg -i spheres_win.i -f mcnp -o all", shell=True)  
+        return_code = subprocess.call("csg2csg -i spheres_win.i -f mcnp -o all", shell=True)
         self.assertEqual(return_code,0)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/makeclean/csg2csg",
     packages=setuptools.find_packages(),
-    scripts=['csg2csg/csg2csg'], #puts files in /usr/local/bin
+    entry_points= dict(console_scripts=['csg2csg=csg2csg.__main__:main']),
     install_requires=['numpy'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This takes care of ensuring the python interpreter used to install the package is used to run the script. Should reduce runtime errors if users decide to attempt to use a different python interpreter.