### PR TITLE
added auto pypi uploading action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,51 @@
+# This yml file will trigger a Github Actions event that builds and upload the
+# Python package to PiPy. This makes use of Twine and is triggered when a push
+# to the main branch occures. For more information see:
+# https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+# and for details on the Autobump version section see:
+# https://github.com/grst/python-ci-versioneer
+
+name: Upload Python Package
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Autobump version
+      run: |
+        # from refs/tags/v1.2.3 get 1.2.3
+        VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+        PLACEHOLDER='version="develop"'
+        VERSION_FILE='setup.py'
+        # Grep checks that the placeholder is in the file. If grep doesn't find
+        # the placeholder then it exits with exit code 1 and github actions fails.
+        grep "$PLACEHOLDER" "$VERSION_FILE"
+        sed -i "s@$PLACEHOLDER@version=\"${VERSION}\"@g" "$VERSION_FILE"
+      shell: bash
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="csg2csg",
-    version="0.0.27",
+    version="develop",
     author="andrew davis",
     author_email="andrew.davis@ukaea.uk",
     description="Convert CSG geometry into different formats",


### PR DESCRIPTION
This adds a github action that will upload the package to pypi whenever a github release is made

the version number from the release will be automatically used in the python package version

for this to work a new github secret called ```PYPI_API_TOKEN``` will need adding