### PR TITLE
Added preserve_xsid capability

### DIFF
--- a/csg2csg/Input.py
+++ b/csg2csg/Input.py
@@ -8,9 +8,10 @@ class InputDeck:
     
     """ Constructor
     """
-    def __init__(self, filename, quick = False):
+    def __init__(self, filename, quick = False, preserve_xsid = False):
         self.filename = filename
         self.quick_process = quick
+        self.preserve_xsid = preserve_xsid
 
         self.file_lines = ""
         self.title = ""
@@ -70,6 +71,7 @@ class InputDeck:
     # instanciate from input
     def from_input(self,InputDeckClass):
         self.filename = InputDeckClass.filename
+        self.preserve_xsid = InputDeckClass.preserve_xsid
         self.title = InputDeckClass.title
         self.cell_list = InputDeckClass.cell_list
         self.surface_list = InputDeckClass.surface_list

--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -29,11 +29,11 @@ import re
 class MCNPInput(InputDeck):
     """ MCNPInputDeck class - does the actuall processing
     """
-    preserve_xsid = False
+    #preserve_xsid = False
 
     # constructor
-    def __init__(self, filename ="", quick = False):
-        InputDeck.__init__(self,filename, quick)
+    def __init__(self, filename ="", quick = False, preserve_xsid = False):
+        InputDeck.__init__(self,filename, quick, preserve_xsid)
 #        self.process()
 
     # TODO - maybe make a function that aribitrarily extract text

--- a/csg2csg/SerpentInput.py
+++ b/csg2csg/SerpentInput.py
@@ -13,8 +13,8 @@ class SerpentInput(InputDeck):
     """
 
     # constructor
-    def __init__(self,filename = ""):
-        InputDeck.__init__(self,filename)
+    def __init__(self,filename = "",preserve_xsid=False):
+        InputDeck.__init__(self,filename,preserve_xsid)
         
     # extract a material card from the start line until
     def __get_material_card(self, start_line, mat_num):
@@ -120,7 +120,7 @@ class SerpentInput(InputDeck):
     def __write_serpent_materials(self, filestream):
         filestream.write("% --- material definitions --- %\n")
         for material in self.material_list:
-            write_serpent_material(filestream, self.material_list[material])
+            write_serpent_material(filestream, self.material_list[material], self.preserve_xsid)
         return
     
     # main write serpent method, depending upon where the geometry

--- a/csg2csg/SerpentMaterialCard.py
+++ b/csg2csg/SerpentMaterialCard.py
@@ -4,7 +4,7 @@ from csg2csg.MaterialCard import MaterialCard
 from csg2csg.MCNPFormatter import get_fortran_formatted_number
 
 # write a specific serpent material card
-def write_serpent_material(filestream, material):
+def write_serpent_material(filestream, material, preserve_xs):
 
     string = "% " + material.material_name  +"\n"
     string += "mat " + str(material.material_number) + " "
@@ -17,7 +17,11 @@ def write_serpent_material(filestream, material):
         string += "\n"
         
     for nuc in material.composition_dictionary:
-        string += '{} {:e} \n'.format(nuc, material.composition_dictionary[nuc])
+        if preserve_xs:
+            string += '{}.{} {:e} \n'.format(nuc, material.xsid_dictionary[nuc], material.composition_dictionary[nuc])
+        else:    
+            string += '{} {:e} \n'.format(nuc, material.composition_dictionary[nuc])
+
     filestream.write(string)
     return
 

--- a/csg2csg/__main__.py
+++ b/csg2csg/__main__.py
@@ -52,6 +52,10 @@ def main():
                         help = 'Perform quick translation, skip surface comparison - model may not transport',
                         action = "store_true")
 
+    parser.add_argument('-xs','--preserve_xsid', 
+                        help = 'Retain xs library for materials',
+                        action = "store_true")
+
     # parse the arguments
     args = parser.parse_args(argv)
 
@@ -71,12 +75,12 @@ def main():
 
     if args.format == 'mcnp':
         # read the mcnp input
-        input = MCNPInput(filename,args.quick)
+        input = MCNPInput(filename,args.quick,args.preserve_xsid)
         input.read()
         input.process()
     elif args.format == 'serpent':
         # read the serpent input
-        input = SerpentInput(filename)
+        input = SerpentInput(filename,args.preserve_xsid)
         input.read()
         input.process()
     elif args.format == 'openmc':


### PR DESCRIPTION
I have added capability to retain xs library data from mcnp and serpent input files, which is invoked by a new command line argument, -xs.