### PR TITLE
Fixed _get_importances bug

### DIFF
--- a/csg2csg/MCNPInput.py
+++ b/csg2csg/MCNPInput.py
@@ -98,7 +98,7 @@ class MCNPInput(InputDeck):
                 return self.__process_importances()
 
             # check for importance keyword
-            if "imp" in self.file_lines[idx]:
+            if self.file_lines[idx].startswith('imp'):
                 particle = self.file_lines[idx].split()[0].split(":")[1]
 
                 # TODO mcnp allows the following forms imp:n imp:n,p etc


### PR DESCRIPTION
Was attempting to convert an MCNP file, which had the word 'implicit' in one of the tally comment cards. This broke the _get_importances function in MCNPInputs so fixed with a startswith operation on the string.